### PR TITLE
Add PromptTemplate class with citation support

### DIFF
--- a/force-app/main/default/classes/AgentMemory.cls
+++ b/force-app/main/default/classes/AgentMemory.cls
@@ -68,31 +68,11 @@ public with sharing class AgentMemory {
     }
     
     private String callPrompt(String consolidated, String newMemories) {
-        String result = 'Mock response';
-
-        if(!Test.isRunningTest()) {
-            ConnectApi.WrappedValue consolidatedMemoryValue = new ConnectApi.WrappedValue();
-            consolidatedMemoryValue.value = consolidated;
-            
-            ConnectApi.WrappedValue newMemoryValue = new ConnectApi.WrappedValue();
-            newMemoryValue.value = newMemories;
-            
-            ConnectApi.EinsteinPromptTemplateGenerationsInput input = new ConnectApi.EinsteinPromptTemplateGenerationsInput();
-            input.additionalConfig = new ConnectApi.EinsteinLlmAdditionalConfigInput();
-            input.additionalConfig.applicationName = 'PromptBuilderPreview';
-            input.isPreview = false;
-            input.inputParams = new Map<String, ConnectApi.WrappedValue>{
-                'Input:consolidatedMemory' => consolidatedMemoryValue,
-                'Input:newMemory' => newMemoryValue
-            };
-            
-            ConnectApi.EinsteinPromptTemplateGenerationsRepresentation output = 
-                ConnectApi.EinsteinLLM.generateMessagesForPromptTemplate('ConsolidateMemory', input);
-            
-            result = output.generations[0].text;
-        }
-
-        return result;
+        return new PromptTemplate('ConsolidateMemory')
+            .call(new Map<String, Object>{
+                'Input:consolidatedMemory' => consolidated,
+                'Input:newMemory' => newMemories
+            }).text;
     }
     
     private void updateConsolidated(String content) {

--- a/force-app/main/default/classes/PromptTemplate.cls
+++ b/force-app/main/default/classes/PromptTemplate.cls
@@ -1,0 +1,133 @@
+public with sharing class PromptTemplate {
+
+    private String templateName;
+
+    @TestVisible
+    private static String mockedResult = 'Test Generated Content Lorem Ipsum';
+
+    // CONSTRUCTORS
+
+    public PromptTemplate(String templateName) {
+        this.templateName = templateName;
+    }
+
+    // PUBLIC
+
+    public Result call(Map<String, Object> inputParams) {
+        Result result = new Result();
+        result.text = mockedResult;
+
+        if(!Test.isRunningTest()) {
+            ConnectApi.EinsteinPromptTemplateGenerationsRepresentation output = invokeTemplate(templateName, inputParams);
+            validateOutput(output, templateName);
+            result.text = output.generations[0].text;
+            result.citations = toGenAiCitation(output.citations?.sourceReferences);
+        }
+
+        return result;
+    }
+
+
+    // PRIVATE
+
+    private static void validateOutput(ConnectApi.EinsteinPromptTemplateGenerationsRepresentation output, String templateName) {
+        if (hasGenerationErrors(output)) {
+            throw new PromptTemplateException(buildErrorMessage(output.generationErrors));
+        }
+
+        if (hasNoGenerations(output)) {
+            throw new PromptTemplateException('No generations returned from: ' + templateName);
+        }
+    }
+
+    private static Boolean hasGenerationErrors(ConnectApi.EinsteinPromptTemplateGenerationsRepresentation output) {
+        return output.generationErrors != null && !output.generationErrors.isEmpty();
+    }
+
+    private static Boolean hasNoGenerations(ConnectApi.EinsteinPromptTemplateGenerationsRepresentation output) {
+        return output.generations == null || output.generations.isEmpty();
+    }
+
+    private ConnectApi.EinsteinPromptTemplateGenerationsRepresentation invokeTemplate(String templateName, Map<String, Object> inputParams) {
+        Map<String, ConnectApi.WrappedValue> params = new Map<String, ConnectApi.WrappedValue>();
+        for(String key : inputParams.keySet()) {
+            params.put(key, wrap(inputParams.get(key)));
+        }
+
+        ConnectApi.EinsteinPromptTemplateGenerationsInput input = new ConnectApi.EinsteinPromptTemplateGenerationsInput();
+        input.additionalConfig = new ConnectApi.EinsteinLlmAdditionalConfigInput();
+        input.additionalConfig.applicationName = 'PromptBuilderPreview';
+        input.isPreview = false;
+        input.inputParams = params;
+        input.citationMode = 'post_generation';
+
+        return ConnectApi.EinsteinLLM.generateMessagesForPromptTemplate(templateName, input);
+    }
+
+    private static String buildErrorMessage(List<ConnectApi.EinsteinPromptTemplateGenerationsError> errors) {
+        List<String> result = new List<String>();
+
+        for(ConnectApi.EinsteinPromptTemplateGenerationsError error : errors) {
+            result.add(error.errorMessage);
+        }
+
+        return String.join(result, '; ');
+    }
+
+
+    private static ConnectApi.WrappedValue wrap(Object value) {
+        ConnectApi.WrappedValue result = new ConnectApi.WrappedValue();
+        Boolean isSObject = value instanceof SObject;
+        result.value = isSObject ? new Map<String, String>{ 'id' => String.valueOf(((SObject) value).Id) } : value;
+
+        return result;
+    }
+
+
+    private static AiCopilot.GenAiCitationInput toGenAiCitation(List<ConnectApi.EinsteinLlmGenAiSourceReference> sourceRefs) {
+        List<AiCopilot.GenAiSourceReference> result = new List<AiCopilot.GenAiSourceReference>();
+
+        if (sourceRefs != null) {
+            for (ConnectApi.EinsteinLlmGenAiSourceReference sourceRef : sourceRefs) {
+                List<AiCopilot.GenAiSourceContentInfo> contents = toGenAiSourceContentInfo(sourceRef.contents);
+                List<AiCopilot.GenAiSourceReferenceInfo> metadata = toGenAiSourceReferenceInfo(sourceRef.metadata);
+
+                result.add(new AiCopilot.GenAiSourceReference(null, contents, metadata));
+            }
+        }
+
+        return new AiCopilot.GenAiCitationInput(null, result);
+    }
+
+
+    private static List<AiCopilot.GenAiSourceContentInfo> toGenAiSourceContentInfo(List<ConnectApi.EinsteinLlmGenerationGenAiSourceContentInfo> contentInfo) {
+        List<AiCopilot.GenAiSourceContentInfo> result = new List<AiCopilot.GenAiSourceContentInfo>();
+
+        for (ConnectApi.EinsteinLlmGenerationGenAiSourceContentInfo content : contentInfo) {
+            result.add(new AiCopilot.GenAiSourceContentInfo(content.fieldName, content.objectName, content.content));
+        }
+
+        return result;
+    }
+
+
+    private static List<AiCopilot.GenAiSourceReferenceInfo> toGenAiSourceReferenceInfo(List<ConnectApi.EinsteinLlmGenerationGenAiSourceReferenceInfo> referenceInfos) {
+        List<AiCopilot.GenAiSourceReferenceInfo> result = new List<AiCopilot.GenAiSourceReferenceInfo>();
+
+        for (ConnectApi.EinsteinLlmGenerationGenAiSourceReferenceInfo referenceInfo : referenceInfos) {
+            result.add(new AiCopilot.GenAiSourceReferenceInfo(referenceInfo.link, referenceInfo.sourceObjectRecordId, referenceInfo.sourceObjectApiName));
+        }
+
+        return result;
+    }
+
+
+    // INNER
+
+    public class Result {
+        public String text;
+        public AiCopilot.GenAiCitationInput citations;
+    }
+
+    public class PromptTemplateException extends Exception {}
+}

--- a/force-app/main/default/classes/PromptTemplate.cls-meta.xml
+++ b/force-app/main/default/classes/PromptTemplate.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/PromptTemplate_Test.cls
+++ b/force-app/main/default/classes/PromptTemplate_Test.cls
@@ -1,0 +1,45 @@
+@IsTest
+private class PromptTemplate_Test {
+
+    @IsTest
+    private static void callReturnsGeneratedText() {
+
+        // Exercise
+        PromptTemplate.Result result = new PromptTemplate('TestTemplate')
+            .call(new Map<String, Object>{
+                'Input:query' => 'test question'
+            });
+
+        // Verify
+        Assert.areEqual(PromptTemplate.mockedResult, result.text);
+    }
+
+
+    @IsTest
+    private static void callWithMultipleParams() {
+
+        // Exercise
+        PromptTemplate.Result result = new PromptTemplate('TestTemplate')
+            .call(new Map<String, Object>{
+                'Input:param1' => 'value1',
+                'Input:param2' => 'value2'
+            });
+
+        // Verify
+        Assert.areEqual(PromptTemplate.mockedResult, result.text);
+    }
+
+
+    @IsTest
+    private static void citationsAreNullInTestContext() {
+
+        // Exercise
+        PromptTemplate.Result result = new PromptTemplate('TestTemplate')
+            .call(new Map<String, Object>{
+                'Input:query' => 'test'
+            });
+
+        // Verify
+        Assert.isNull(result.citations);
+    }
+}

--- a/force-app/main/default/classes/PromptTemplate_Test.cls-meta.xml
+++ b/force-app/main/default/classes/PromptTemplate_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## Summary

- Extract reusable `PromptTemplate` class that wraps ConnectApi prompt template invocation with proper error handling
- Add citation and source tracking: sets `citationMode = 'post_generation'` and converts `ConnectApi` citations to `AiCopilot.GenAiCitationInput` for Agentforce to render clickable source references
- Refactor `AgentMemory` to use the new class (25 lines → 5 lines)

Closes #37

## Test plan

- [x] `PromptTemplate_Test` — 3 tests passing
- [x] Deployed to scratch org successfully
- [ ] Verify agent memory consolidation still works end-to-end
- [ ] Verify citation rendering in Agentforce when using grounded prompt templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)