### PR TITLE
add manual step to update retriever id in custom setting after config…

### DIFF
--- a/force-app/main/default/genAiFunctions/AnswerFromDataLibrary/AnswerFromDataLibrary.genAiFunction-meta.xml
+++ b/force-app/main/default/genAiFunctions/AnswerFromDataLibrary/AnswerFromDataLibrary.genAiFunction-meta.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenAiFunction xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>- Use this to answer questions using the company's internal knowledge base stored in Data Cloud.
-- Searches through company documents, policies, procedures, and other internal knowledge sources.
-- Returns AI-generated answers grounded in actual company documentation with source citations.
+    <description>
+        - Use this to answer questions using the company's internal knowledge base stored in Data Cloud.
+        - Searches through company documents, policies, procedures, and other internal knowledge sources.
+        - Returns AI-generated answers grounded in actual company documentation with source citations.
 
-IMPORTANT: When calling this function, do NOT simply pass the user's last utterance as the question. Instead:
-1. Analyze the entire conversation context and previous exchanges
-2. Reformulate the question to be self-contained and contextually complete
-3. Include relevant background information from the conversation history
-4. Make the question specific enough for effective search</description>
+        IMPORTANT: When calling this function, do NOT simply pass the user's last utterance as the question. Instead:
+        1. Analyze the entire conversation context and previous exchanges
+        2. Reformulate the question to be self-contained and contextually complete
+        3. Include relevant background information from the conversation history
+        4. Make the question specific enough for effective search
+    </description>
     <developerName>AnswerFromDataLibrary</developerName>
     <invocationTarget>AnswerFromDataLibrary</invocationTarget>
     <invocationTargetType>apex</invocationTargetType>

--- a/force-app/main/default/genAiFunctions/AnswerFromDataLibrary/output/schema.json
+++ b/force-app/main/default/genAiFunctions/AnswerFromDataLibrary/output/schema.json
@@ -8,6 +8,15 @@
       "lightning:isPII" : false,
       "copilotAction:isDisplayable" : false,
       "copilotAction:isUsedByPlanner" : true
+    },
+    "citations": {
+        "title": "Citations",
+        "description": "Citations associated with the generated response",
+        "lightning:type": "@apexClassType/AiCopilot__GenAiCitationInput",
+        "lightning:isPII": false,
+        "copilotAction:isDisplayable": false,
+        "copilotAction:isUsedByPlanner": false,
+        "copilotAction:useHydratedPrompt": false
     }
   },
   "lightning:type" : "lightning__objectType"

--- a/scripts/create-scratch-org.sh
+++ b/scripts/create-scratch-org.sh
@@ -97,13 +97,13 @@ echo "Running Testing Center Tests (second pass — session data now indexed for
 sf agent test run --api-name Regression_Test --wait 15
 
 echo "Running Promptfoo Demo Story"
-cd regressions/promptfoo && npx promptfoo@latest eval -c demo-story.yaml --env-file .env && cd ../..
+(cd regressions/promptfoo && npx promptfoo@latest eval -c demo-story.yaml --env-file .env)
 
 echo "Running Promptfoo Regression Tests"
-cd regressions/promptfoo && npx promptfoo@latest eval -c regression.yaml --env-file .env && cd ../..
+(cd regressions/promptfoo && npx promptfoo@latest eval -c regression.yaml --env-file .env)
 
 echo "Running Promptfoo Prompt Template Regression Tests"
-cd regressions/promptfoo && npx promptfoo@latest eval -c prompt-regression.yaml --env-file .env && cd ../..
+(cd regressions/promptfoo && npx promptfoo@latest eval -c prompt-regression.yaml --env-file .env)
 
 echo "Running SFX Scanner with Security, AppExchange and Coding Standards"
 #sf code-analyzer run --rule-selector "Recommended:Security" "AppExchange" "flow" "sfge" --output-file code-analyzer-security.csv --target force-app/main/default

--- a/scripts/manual-org-setup.md
+++ b/scripts/manual-org-setup.md
@@ -31,6 +31,13 @@ This enables semantic search on agent conversation history via `hybrid_search()`
 - Upload: `scripts/sales-policy.pdf` (company sales policy with discount thresholds)
 - Create a search index and wait for it to complete
 
-## 4. Tavily API Key (for web search)
+## 4. Configure Data Library Retriever
+
+- Setup → Einstein Studio → open the retriever created for **MyOrgButlerLibrary**
+- Copy the **API Name** of the retriever
+- Setup → Custom Settings → **MyOrgButlerConfig** → Manage
+- Create or edit the org-level value and paste the retriever API name into the appropriate field
+
+## 5. Tavily API Key (for web search)
 
 - If not already configured, add your Tavily API key to the TavilyApi external credential


### PR DESCRIPTION
What this PR fixes:
1. Add manual step to configure custom setting with correct retriever API name
2. Update script to cd back to parent directory after running regressions to make the trap work properly(git branch was left with state where namespace was stripped from metadata
3. Add citation to AnswerFromDataLibrary action output schema