### PR TITLE
Add full-document semantic search to Answer from Data Library

### DIFF
--- a/force-app/main/default/classes/AnswerFromDataLibrary.cls
+++ b/force-app/main/default/classes/AnswerFromDataLibrary.cls
@@ -9,7 +9,8 @@ global with sharing class AnswerFromDataLibrary {
         PromptTemplate.Result result = new PromptTemplate('AnswerFromDataLibrary')
                             .call(new Map<String, Object>{
                                 'Input:userQuestion' => input.question,
-                                'Input:RetrieverId' => CustomSettings.valueFor('DataLibraryRetriever')
+                                'Input:RetrieverId' => CustomSettings.valueFor('DataLibraryRetriever'),
+                                'Input:documentContext' => new SemanticSearch().execute(input.question, CustomSettings.optionalValueFor('DataLibraryChunkDmo'))
                             });
 
         Output output = new Output();

--- a/force-app/main/default/classes/CdpQuery.cls
+++ b/force-app/main/default/classes/CdpQuery.cls
@@ -1,0 +1,8 @@
+public virtual with sharing class CdpQuery {
+
+    public virtual ConnectApi.CdpQueryOutputV2 query(String sql) {
+        ConnectApi.CdpQueryInput input = new ConnectApi.CdpQueryInput();
+        input.sql = sql;
+        return ConnectApi.CdpQuery.queryANSISqlV2(input);
+    }
+}

--- a/force-app/main/default/classes/CdpQuery.cls-meta.xml
+++ b/force-app/main/default/classes/CdpQuery.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CustomSettings.cls
+++ b/force-app/main/default/classes/CustomSettings.cls
@@ -4,12 +4,17 @@ public with sharing class CustomSettings {
     
     public static String valueFor(String settingName) {
         CustomSetting__c setting = CustomSetting__c.getValues(settingName);
-        
+
         if (setting == null) {
             throw new ApplicationException('Custom Setting not found: ' + settingName);
         }
-        
+
         return setting.Value__c;
+    }
+
+    public static String optionalValueFor(String settingName) {
+        CustomSetting__c setting = CustomSetting__c.getValues(settingName);
+        return setting != null ? setting.Value__c : null;
     }
     
     @TestVisible

--- a/force-app/main/default/classes/CustomSettings_Test.cls
+++ b/force-app/main/default/classes/CustomSettings_Test.cls
@@ -1,0 +1,56 @@
+@IsTest
+private class CustomSettings_Test {
+
+    @IsTest
+    private static void returnsValueForExistingSetting() {
+
+        // Setup
+        CustomSettings.mock('TestSetting', 'test-value');
+
+        // Exercise & Verify
+        Assert.areEqual('test-value', CustomSettings.valueFor('TestSetting'));
+    }
+
+
+    @IsTest
+    private static void throwsWhenSettingNotFound() {
+        // Setup
+        Exception expectedException = null;
+
+        // Exercise
+        try {
+            CustomSettings.valueFor('NonExistent');
+        } catch (ApplicationException e) {
+            expectedException = e;
+        }
+
+        // Verify
+        Assert.isNotNull(expectedException);
+        Assert.areEqual('Custom Setting not found: NonExistent', expectedException.getMessage());
+    }
+
+
+    @IsTest
+    private static void returnsNullForMissingOptionalSetting() {
+
+        // Exercise
+        String result = CustomSettings.optionalValueFor('NonExistent');
+
+        // Verify
+        Assert.isNull(result);
+    }
+
+
+    @IsTest
+    private static void returnsValueForExistingOptionalSetting() {
+
+        // Setup
+        CustomSettings.mock('TestSetting', 'test-value');
+
+        // Exercise
+        String result = CustomSettings.optionalValueFor('TestSetting');
+
+        // Verify
+        Assert.areEqual('test-value', result);
+    }
+}

--- a/force-app/main/default/classes/CustomSettings_Test.cls-meta.xml
+++ b/force-app/main/default/classes/CustomSettings_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SemanticSearch.cls
+++ b/force-app/main/default/classes/SemanticSearch.cls
@@ -1,0 +1,143 @@
+public with sharing class SemanticSearch {
+
+    private static final Integer DEFAULT_TOP_K = 10;
+    private static final Decimal DEFAULT_SIMILARITY_THRESHOLD = 0.4;
+    private static final Integer MAX_CHUNKS = 1000;
+
+    @TestVisible
+    private CdpQuery cdpQuery = new CdpQuery();
+
+
+    // PUBLIC
+
+    public String execute(String query, String chunkDmo) {
+        String result = '';
+
+        if (String.isNotBlank(chunkDmo)) {
+            String searchIndex = deriveSearchIndex(chunkDmo);
+            Set<String> documentIds = findRelevantDocuments(query, searchIndex, chunkDmo);
+
+            if (!documentIds.isEmpty()) {
+                result = formatAsText(fetchChunks(documentIds, chunkDmo));
+            }
+        }
+
+        return result;
+    }
+
+
+    // PRIVATE
+
+
+    private String deriveSearchIndex(String chunkDmo) {
+        return chunkDmo.replace('_chunk__dlm', '_index__dlm');
+    }
+
+
+    private Set<String> findRelevantDocuments(String query, String searchIndex, String chunkDmo) {
+        String sql = buildHybridSearchSql(query, searchIndex, chunkDmo);
+        return extractDocumentIds(cdpQuery.query(sql));
+    }
+
+
+    private String buildHybridSearchSql(String query, String searchIndex, String chunkDmo) {
+        String escapedQuery = query.replace('\'', '');
+        String threshold = String.valueOf(DEFAULT_SIMILARITY_THRESHOLD);
+        String topK = String.valueOf(DEFAULT_TOP_K);
+
+        return String.format(
+            'SELECT DISTINCT c.SourceRecordId__c ' +
+            'FROM hybrid_search(TABLE({0}), \'\'{1}\'\', \'\'\'\', {2}) h ' +
+            'JOIN {3} c ON h.SourceRecordId__c = c.RecordId__c ' +
+            'WHERE h.hybrid_score__c >= {4} ' +
+            'LIMIT {5}',
+            new List<String>{ searchIndex, escapedQuery, topK, chunkDmo, threshold, topK }
+        );
+    }
+
+
+    private Set<String> extractDocumentIds(ConnectApi.CdpQueryOutputV2 queryResult) {
+        Set<String> result = new Set<String>();
+
+        if (queryResult != null && queryResult.data != null) {
+            for (ConnectApi.CdpQueryV2Row row : queryResult.data) {
+                String docId = getString(row.rowData, 0);
+                if (String.isNotBlank(docId)) {
+                    result.add(docId);
+                }
+            }
+        }
+
+        return result;
+    }
+
+
+    private List<Chunk> fetchChunks(Set<String> documentIds, String chunkDmo) {
+        String sql = buildDocumentQuerySql(documentIds, chunkDmo);
+        return parseChunks(cdpQuery.query(sql));
+    }
+
+
+    private String buildDocumentQuerySql(Set<String> documentIds, String chunkDmo) {
+        List<String> quotedIds = new List<String>();
+        for (String docId : documentIds) {
+            quotedIds.add('\'' + String.escapeSingleQuotes(docId) + '\'');
+        }
+
+        return 'SELECT SourceRecordId__c, Chunk__c FROM ' + chunkDmo + ' ' +
+            'WHERE SourceRecordId__c IN (' + String.join(quotedIds, ', ') + ') ' +
+            'ORDER BY SourceRecordId__c, ChunkSequenceNumber__c ' +
+            'LIMIT ' + String.valueOf(MAX_CHUNKS);
+    }
+
+
+    private List<Chunk> parseChunks(ConnectApi.CdpQueryOutputV2 queryResult) {
+        List<Chunk> result = new List<Chunk>();
+
+        if (queryResult != null && queryResult.data != null) {
+            for (ConnectApi.CdpQueryV2Row row : queryResult.data) {
+                String sourceId = getString(row.rowData, 0);
+                String content = getString(row.rowData, 1);
+
+                if (String.isNotBlank(content)) {
+                    Chunk chunk = new Chunk();
+                    chunk.sourceId = sourceId;
+                    chunk.content = content;
+                    result.add(chunk);
+                }
+            }
+        }
+
+        return result;
+    }
+
+
+    private String formatAsText(List<Chunk> chunks) {
+        List<String> entries = new List<String>();
+
+        for (Chunk chunk : chunks) {
+            entries.add(chunk.content);
+        }
+
+        return String.join(entries, '\n###\n');
+    }
+
+
+    private String getString(List<Object> data, Integer idx) {
+        String result = null;
+
+        if (idx < data.size() && data[idx] != null) {
+            result = String.valueOf(data[idx]);
+        }
+
+        return result;
+    }
+
+
+    // INNER
+
+    private class Chunk {
+        private String sourceId;
+        private String content;
+    }
+}

--- a/force-app/main/default/classes/SemanticSearch.cls-meta.xml
+++ b/force-app/main/default/classes/SemanticSearch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SemanticSearchTest.cls
+++ b/force-app/main/default/classes/SemanticSearchTest.cls
@@ -1,0 +1,189 @@
+@IsTest
+private class SemanticSearchTest {
+
+    private static MockCdpQuery mockCdpQuery = new MockCdpQuery();
+
+
+    @IsTest
+    private static void returnsEmptyResultWhenNoDocumentsFound() {
+
+        // Setup
+        mockCdpQuery.whenQueryContains('hybrid_search', createQueryResult(new List<List<Object>>()));
+
+
+        // Exercise
+        String result = search('test query');
+
+
+        // Verify
+        Assert.areEqual('', result);
+    }
+
+
+    @IsTest
+    private static void returnsFormattedDocumentContent() {
+
+        // Setup
+        mockCdpQuery.whenQueryContains('hybrid_search', createQueryResult(new List<List<Object>>{
+            new List<Object>{ 'doc1' },
+            new List<Object>{ 'doc2' }
+        }));
+
+        mockCdpQuery.whenQueryContains('Chunk__c', createQueryResult(new List<List<Object>>{
+            new List<Object>{ 'doc1', 'Content from document 1' },
+            new List<Object>{ 'doc2', 'Content from document 2' }
+        }));
+
+
+        // Exercise
+        String result = search('maternity policy');
+
+
+        // Verify
+        Assert.isTrue(result.contains('Content from document 1'));
+        Assert.isTrue(result.contains('Content from document 2'));
+    }
+
+
+    @IsTest
+    private static void handlesNullDataInHybridSearchResult() {
+
+        // Setup
+        ConnectApi.CdpQueryOutputV2 queryResult = new ConnectApi.CdpQueryOutputV2();
+        queryResult.data = null;
+        mockCdpQuery.whenQueryContains('hybrid_search', queryResult);
+
+
+        // Exercise
+        String result = search('test query');
+
+
+        // Verify
+        Assert.areEqual('', result);
+    }
+
+
+    @IsTest
+    private static void filtersOutBlankDocumentIds() {
+
+        // Setup
+        mockCdpQuery.whenQueryContains('hybrid_search', createQueryResult(new List<List<Object>>{
+            new List<Object>{ 'doc1' },
+            new List<Object>{ '' },
+            new List<Object>{ null }
+        }));
+
+        mockCdpQuery.whenQueryContains('Chunk__c', createQueryResult(new List<List<Object>>{
+            new List<Object>{ 'doc1', 'Valid content' }
+        }));
+
+
+        // Exercise
+        String result = search('test query');
+
+
+        // Verify
+        Assert.isTrue(result.contains('Valid content'));
+    }
+
+
+    @IsTest
+    private static void derivesSearchIndexFromChunkDmo() {
+
+        // Setup
+        mockCdpQuery.whenQueryContains('hybrid_search', createQueryResult(new List<List<Object>>()));
+
+
+        // Exercise
+        SemanticSearch semanticSearch = new SemanticSearch();
+        semanticSearch.cdpQuery = mockCdpQuery;
+        semanticSearch.execute('test', 'ADL_MyOrgButlerLibr_chunk__dlm');
+
+
+        // Verify
+        Assert.isTrue(mockCdpQuery.lastQuery().contains('ADL_MyOrgButlerLibr_index__dlm'));
+    }
+
+
+    @IsTest
+    private static void usesDefaultSimilarityThreshold() {
+
+        // Setup
+        mockCdpQuery.whenQueryContains('hybrid_search', createQueryResult(new List<List<Object>>()));
+
+
+        // Exercise
+        search('test');
+
+
+        // Verify
+        Assert.isTrue(mockCdpQuery.lastQuery().contains('0.4'));
+    }
+
+
+    @IsTest
+    private static void stripsApostrophesFromQuery() {
+
+        // Setup
+        mockCdpQuery.whenQueryContains('hybrid_search', createQueryResult(new List<List<Object>>()));
+
+
+        // Exercise
+        search('colleague\'s non-working day');
+
+
+        // Verify
+        Assert.isTrue(mockCdpQuery.lastQuery().contains('colleagues non-working day'));
+    }
+
+
+    // HELPER
+
+    private static String search(String query) {
+        SemanticSearch semanticSearch = new SemanticSearch();
+        semanticSearch.cdpQuery = mockCdpQuery;
+        return semanticSearch.execute(query, 'TestChunk_chunk__dlm');
+    }
+
+
+    private static ConnectApi.CdpQueryOutputV2 createQueryResult(List<List<Object>> rows) {
+        ConnectApi.CdpQueryOutputV2 result = new ConnectApi.CdpQueryOutputV2();
+        result.data = new List<ConnectApi.CdpQueryV2Row>();
+
+        for (List<Object> rowData : rows) {
+            ConnectApi.CdpQueryV2Row row = new ConnectApi.CdpQueryV2Row();
+            row.rowData = rowData;
+            result.data.add(row);
+        }
+
+        return result;
+    }
+
+
+    // MOCK
+
+    private class MockCdpQuery extends CdpQuery {
+        private List<String> executedQueries = new List<String>();
+        private Map<String, ConnectApi.CdpQueryOutputV2> responses = new Map<String, ConnectApi.CdpQueryOutputV2>();
+
+        public void whenQueryContains(String pattern, ConnectApi.CdpQueryOutputV2 result) {
+            responses.put(pattern, result);
+        }
+
+        public String lastQuery() {
+            return executedQueries.isEmpty() ? null : executedQueries[executedQueries.size() - 1];
+        }
+
+        public override ConnectApi.CdpQueryOutputV2 query(String sql) {
+            executedQueries.add(sql);
+
+            for (String pattern : responses.keySet()) {
+                if (sql.containsIgnoreCase(pattern)) {
+                    return responses.get(pattern);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/force-app/main/default/classes/SemanticSearchTest.cls-meta.xml
+++ b/force-app/main/default/classes/SemanticSearchTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/genAiPromptTemplates/AnswerFromDataLibrary.genAiPromptTemplate-meta.xml
+++ b/force-app/main/default/genAiPromptTemplates/AnswerFromDataLibrary.genAiPromptTemplate-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenAiPromptTemplate xmlns="http://soap.sforce.com/2006/04/metadata">
-    <activeVersionIdentifier>XKhLCa4sj2JrMpHwkjfDxBEOUi9KooH1VeWEaYBgPsc=_3</activeVersionIdentifier>
+    <activeVersionIdentifier>XKhLCa4sj2JrMpHwkjfDxBEOUi9KooH1VeWEaYBgPsc=_4</activeVersionIdentifier>
     <description>Answers questions using company documents from a Data Cloud data library.</description>
     <developerName>AnswerFromDataLibrary</developerName>
     <masterLabel>Answer from Data Library</masterLabel>
@@ -13,12 +13,16 @@
 &lt;/QUESTION&gt;
 
 &lt;KNOWLEDGE&gt;
-{!$EinsteinSearch:sfdc_ai__DynamicRetriever.results} 
+{!$EinsteinSearch:sfdc_ai__DynamicRetriever.results}
 &lt;/KNOWLEDGE&gt;
+
+&lt;DOCUMENT_CONTEXT&gt;
+{!$Input:documentContext}
+&lt;/DOCUMENT_CONTEXT&gt;
 
 ### Instructions
 
-- Answer using ONLY the information in the KNOWLEDGE section.
+- Answer using ONLY the information in the KNOWLEDGE and DOCUMENT_CONTEXT sections.
 - When you use information from a source, introduce it naturally (e.g. &quot;According to [source name], ...&quot;).
 - If the knowledge doesn&apos;t contain the answer, say so clearly.
 - Start with a TL;DR (1-2 lines), then follow with detail if needed.
@@ -36,6 +40,13 @@
             <definition>primitive://String</definition>
             <masterLabel>RetrieverId</masterLabel>
             <referenceName>Input:RetrieverId</referenceName>
+            <required>false</required>
+        </inputs>
+        <inputs>
+            <apiName>documentContext</apiName>
+            <definition>primitive://String</definition>
+            <masterLabel>documentContext</masterLabel>
+            <referenceName>Input:documentContext</referenceName>
             <required>false</required>
         </inputs>
         <primaryModel>sfdc_ai__DefaultBedrockAnthropicClaude45Sonnet</primaryModel>
@@ -58,7 +69,7 @@
             </parameters>
             <referenceName>EinsteinSearch:sfdc_ai__DynamicRetriever</referenceName>
         </templateDataProviders>
-        <versionIdentifier>XKhLCa4sj2JrMpHwkjfDxBEOUi9KooH1VeWEaYBgPsc=_3</versionIdentifier>
+        <versionIdentifier>XKhLCa4sj2JrMpHwkjfDxBEOUi9KooH1VeWEaYBgPsc=_4</versionIdentifier>
     </templateVersions>
     <type>einstein_gpt__flex</type>
     <visibility>Global</visibility>

--- a/scripts/create-sample-data.apex
+++ b/scripts/create-sample-data.apex
@@ -111,11 +111,20 @@ Opportunity dubaiSponsoring = new Opportunity(
 insert dubaiSponsoring;
 
 
-// CUSTOM SETTINGS
-List<CustomSetting__c> existing = [SELECT Id FROM CustomSetting__c WHERE Name = 'DataLibraryRetriever'];
-if(existing.isEmpty()) {
+// CUSTOM SETTINGS: Data Library retriever
+List<CustomSetting__c> retrieverSettings = [SELECT Id FROM CustomSetting__c WHERE Name = 'DataLibraryRetriever'];
+if(retrieverSettings.isEmpty()) {
     insert as user new CustomSetting__c(Name = 'DataLibraryRetriever', Value__c = 'MyOrgButlerLibrary');
 } else {
-    existing[0].put('Value__c', 'MyOrgButlerLibrary');
-    update as user existing;
+    retrieverSettings[0].put('Value__c', 'MyOrgButlerLibrary');
+    update as user retrieverSettings;
+}
+
+// CUSTOM SETTING: Data Library chunk DMO
+List<CustomSetting__c> chunkDmoSettings = [SELECT Id FROM CustomSetting__c WHERE Name = 'DataLibraryChunkDmo'];
+if(chunkDmoSettings.isEmpty()) {
+    insert as user new CustomSetting__c(Name = 'DataLibraryChunkDmo', Value__c = 'ADL_MyOrgButlerLibr_chunk__dlm');
+} else {
+    chunkDmoSettings[0].put('Value__c', 'ADL_MyOrgButlerLibr_chunk__dlm');
+    update as user chunkDmoSettings;
 }


### PR DESCRIPTION
When the `DataLibraryChunkDmo` custom setting is configured, the action now performs a hybrid search against Data Cloud to retrieve full document context and passes it to the prompt template alongside the existing DynamicRetriever knowledge. This gives the LLM richer context to ground its answers in, especially for questions that span multiple chunks.

Key changes:
- CdpQuery: virtual wrapper around ConnectApi.CdpQuery for testability
- SemanticSearch: hybrid search + chunk retrieval against Data Cloud
- CustomSettings.optionalValueFor: nullable lookup for optional settings
- AnswerFromDataLibrary prompt template: new documentContext input