### PR TITLE
Replace ConnectApi.CdpQuery with REST to support non-Data Cloud orgs

### DIFF
--- a/force-app/main/default/classes/DataCloudSql.cls
+++ b/force-app/main/default/classes/DataCloudSql.cls
@@ -1,0 +1,35 @@
+@SuppressWarnings('PMD.ApexSuggestUsingNamedCred')
+public with sharing class DataCloudSql {
+
+    private static final String QUERY_ENDPOINT = '/services/data/v66.0/ssot/query-sql';
+
+    @TestVisible
+    private static String mockedResponse;
+
+
+    public static String query(String sql) {
+
+        System.debug('sql >>' + sql);
+        if (Test.isRunningTest() && mockedResponse != null) {
+            return mockedResponse;
+        }
+
+        HttpRequest request = new HttpRequest();
+        request.setMethod('POST');
+        request.setHeader('Authorization', 'Bearer ' + new SessionId().asString());
+        request.setHeader('Content-Type', 'application/json');
+        request.setEndpoint(Url.getOrgDomainURL().toExternalForm() + QUERY_ENDPOINT);
+        request.setBody(JSON.serialize(new Map<String, String>{ 'sql' => sql }));
+
+        HttpResponse response = new Http().send(request);
+
+        if (response.getStatusCode() >= 400) {
+            throw new DataCloudException('Data Cloud query error (' + response.getStatusCode() + '): ' + response.getBody());
+        }
+
+        return response.getBody();
+    }
+
+
+    public class DataCloudException extends Exception {}
+}

--- a/force-app/main/default/classes/DataCloudSql.cls-meta.xml
+++ b/force-app/main/default/classes/DataCloudSql.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DataLibrary.cls
+++ b/force-app/main/default/classes/DataLibrary.cls
@@ -24,16 +24,21 @@ public virtual with sharing class DataLibrary {
 
         Result result = new Result();
 
-        String searchIndex = chunkDmo.replace('_chunk', '_index');
-        Set<String> documentIds = findRelevantDocumentIds(query, searchIndex, chunkDmo);
+        try {
+            String searchIndex = chunkDmo.replace('_chunk', '_index');
+            Set<String> documentIds = findRelevantDocumentIds(query, searchIndex, chunkDmo);
 
-        if (!documentIds.isEmpty()) {
-            ConnectApi.CdpQueryOutputV2 chunkRows = chunksOnly
-                ? queryChunksFor(query, searchIndex, chunkDmo)
-                : queryAllChunksOf(documentIds, chunkDmo);
+            if (!documentIds.isEmpty()) {
+                QueryResult chunkRows = chunksOnly
+                    ? queryChunksFor(query, searchIndex, chunkDmo)
+                    : queryAllChunksOf(documentIds, chunkDmo);
 
-            result.documents = toJson(chunkRows, chunksOnly);
-            result.citations = new PresignedCitations(chunkDmo).forDocuments(documentIds);
+                result.documents = toJson(chunkRows, chunksOnly);
+                result.citations = new PresignedCitations(chunkDmo).forDocuments(documentIds);
+            }
+        }
+        catch (Exception error) {
+            System.debug(LoggingLevel.ERROR, 'DataLibrary: ' + error.getMessage());
         }
 
         return result;
@@ -43,15 +48,24 @@ public virtual with sharing class DataLibrary {
     // PROTECTED
 
     @TestVisible
-    protected virtual ConnectApi.CdpQueryOutputV2 queryCdp(String sql) {
-        ConnectApi.CdpQueryInput input = new ConnectApi.CdpQueryInput();
-        input.sql = sql;
+    protected virtual QueryResult queryCdp(String sql) {
+        Map<String, Object> parsed = (Map<String, Object>) JSON.deserializeUntyped(DataCloudSql.query(sql));
+        List<Object> rows = (List<Object>) parsed.get('data');
 
-        return ConnectApi.CdpQuery.queryANSISqlV2(input);
+        QueryResult result = new QueryResult();
+        result.data = new List<QueryRow>();
+
+        if (rows != null) {
+            for (Object row : rows) {
+                QueryRow qr = new QueryRow();
+                qr.rowData = (List<Object>) row;
+                result.data.add(qr);
+            }
+        }
+
+        return result;
     }
 
-
-    // PRIVATE
 
     private Set<String> findRelevantDocumentIds(String query, String searchIndex, String chunkDmo) {
         Set<String> result = new Set<String>();
@@ -60,7 +74,7 @@ public virtual with sharing class DataLibrary {
         String topK = String.valueOf(DEFAULT_TOP_K);
         String threshold = String.valueOf(DEFAULT_SIMILARITY_THRESHOLD);
 
-        ConnectApi.CdpQueryOutputV2 queryResult = queryCdp(
+        QueryResult queryResult = queryCdp(
             'SELECT DISTINCT c.SourceRecordId__c ' +
             'FROM hybrid_search(TABLE(' + searchIndex + '), \'' + escapedQuery + '\', \'\', ' + topK + ') h ' +
             'JOIN ' + chunkDmo + ' c ON h.SourceRecordId__c = c.RecordId__c ' +
@@ -69,7 +83,7 @@ public virtual with sharing class DataLibrary {
         );
 
         if (queryResult != null && queryResult.data != null) {
-            for (ConnectApi.CdpQueryV2Row row : queryResult.data) {
+            for (QueryRow row : queryResult.data) {
                 String docId = rowValue(row, 0);
 
                 if (String.isNotBlank(docId)) {
@@ -82,7 +96,7 @@ public virtual with sharing class DataLibrary {
     }
 
 
-    private ConnectApi.CdpQueryOutputV2 queryChunksFor(String query, String searchIndex, String chunkDmo) {
+    private QueryResult queryChunksFor(String query, String searchIndex, String chunkDmo) {
         String escapedQuery = String.escapeSingleQuotes(query);
         String topK = String.valueOf(DEFAULT_TOP_K);
         String threshold = String.valueOf(DEFAULT_SIMILARITY_THRESHOLD);
@@ -97,7 +111,7 @@ public virtual with sharing class DataLibrary {
     }
 
 
-    private ConnectApi.CdpQueryOutputV2 queryAllChunksOf(Set<String> documentIds, String chunkDmo) {
+    private QueryResult queryAllChunksOf(Set<String> documentIds, String chunkDmo) {
         return queryCdp(
             'SELECT SourceRecordId__c, Chunk__c FROM ' + chunkDmo + ' ' +
             'WHERE SourceRecordId__c IN (' + toSqlList(documentIds) + ') ' +
@@ -118,11 +132,11 @@ public virtual with sharing class DataLibrary {
     }
 
 
-    private String toJson(ConnectApi.CdpQueryOutputV2 queryResult, Boolean chunksOnly) {
+    private String toJson(QueryResult queryResult, Boolean chunksOnly) {
         Map<String, Document> bySourceId = new Map<String, Document>();
 
         if (queryResult != null && queryResult.data != null) {
-            for (ConnectApi.CdpQueryV2Row row : queryResult.data) {
+            for (QueryRow row : queryResult.data) {
                 String sourceRecordId = rowValue(row, 0);
                 String content = rowValue(row, 1);
 
@@ -151,7 +165,7 @@ public virtual with sharing class DataLibrary {
     }
 
 
-    private String rowValue(ConnectApi.CdpQueryV2Row row, Integer idx) {
+    private String rowValue(QueryRow row, Integer idx) {
         String result = null;
 
         if (idx < row.rowData.size() && row.rowData[idx] != null) {
@@ -167,6 +181,18 @@ public virtual with sharing class DataLibrary {
     public class Result {
         public String documents = '';
         public AiCopilot.GenAiCitationInput citations;
+    }
+
+
+    @TestVisible
+    class QueryResult {
+        @TestVisible List<QueryRow> data;
+    }
+
+
+    @TestVisible
+    class QueryRow {
+        @TestVisible List<Object> rowData;
     }
 
 

--- a/force-app/main/default/classes/DataLibrary_Test.cls
+++ b/force-app/main/default/classes/DataLibrary_Test.cls
@@ -5,7 +5,7 @@ private class DataLibrary_Test {
     private static MockDataLibrary mock = new MockDataLibrary();
 
     static {
-        PresignedCitations.mockedRestResponse = '{"data":[],"metadata":[]}';
+        DataCloudSql.mockedResponse = '{"data":[],"metadata":[]}';
     }
 
 
@@ -85,7 +85,7 @@ private class DataLibrary_Test {
     private static void returnsEmptyForNullResult() {
 
         // Setup
-        ConnectApi.CdpQueryOutputV2 queryResult = new ConnectApi.CdpQueryOutputV2();
+        DataLibrary.QueryResult queryResult = new DataLibrary.QueryResult();
         queryResult.data = null;
         mock.whenQueryContains('hybrid_search', queryResult);
 
@@ -171,14 +171,27 @@ private class DataLibrary_Test {
     }
 
 
+    @IsTest
+    private static void returnsEmptyOnException() {
+
+        // Exercise
+        DataLibrary.Result result = new ThrowingDataLibrary().retrieve('test query', CHUNK_DMO, false);
+
+
+        // Verify
+        Assert.areEqual('', result.documents);
+        Assert.areEqual(null, result.citations);
+    }
+
+
     // HELPER
 
-    private static ConnectApi.CdpQueryOutputV2 createQueryResult(List<List<Object>> rows) {
-        ConnectApi.CdpQueryOutputV2 result = new ConnectApi.CdpQueryOutputV2();
-        result.data = new List<ConnectApi.CdpQueryV2Row>();
+    private static DataLibrary.QueryResult createQueryResult(List<List<Object>> rows) {
+        DataLibrary.QueryResult result = new DataLibrary.QueryResult();
+        result.data = new List<DataLibrary.QueryRow>();
 
         for (List<Object> rowData : rows) {
-            ConnectApi.CdpQueryV2Row row = new ConnectApi.CdpQueryV2Row();
+            DataLibrary.QueryRow row = new DataLibrary.QueryRow();
             row.rowData = rowData;
             result.data.add(row);
         }
@@ -189,9 +202,9 @@ private class DataLibrary_Test {
 
     private class MockDataLibrary extends DataLibrary {
         private List<String> executedQueries = new List<String>();
-        private Map<String, ConnectApi.CdpQueryOutputV2> responses = new Map<String, ConnectApi.CdpQueryOutputV2>();
+        private Map<String, DataLibrary.QueryResult> responses = new Map<String, DataLibrary.QueryResult>();
 
-        public void whenQueryContains(String pattern, ConnectApi.CdpQueryOutputV2 result) {
+        public void whenQueryContains(String pattern, DataLibrary.QueryResult result) {
             responses.put(pattern, result);
         }
 
@@ -199,8 +212,8 @@ private class DataLibrary_Test {
             return executedQueries.isEmpty() ? null : executedQueries[executedQueries.size() - 1];
         }
 
-        protected override ConnectApi.CdpQueryOutputV2 queryCdp(String sql) {
-            ConnectApi.CdpQueryOutputV2 result = null;
+        protected override DataLibrary.QueryResult queryCdp(String sql) {
+            DataLibrary.QueryResult result = null;
 
             executedQueries.add(sql);
 
@@ -213,6 +226,13 @@ private class DataLibrary_Test {
 
             return result;
         }
+    }
 
+
+    private class ThrowingDataLibrary extends DataLibrary {
+
+        protected override DataLibrary.QueryResult queryCdp(String sql) {
+            throw new QueryException('Data Cloud not available');
+        }
     }
 }

--- a/force-app/main/default/classes/PresignedCitations.cls
+++ b/force-app/main/default/classes/PresignedCitations.cls
@@ -38,6 +38,10 @@ public with sharing class PresignedCitations {
         Map<String, Object> parsed = (Map<String, Object>) JSON.deserializeUntyped(responseBody);
         List<Object> rows = (List<Object>) parsed.get('data');
 
+        if (rows == null) {
+            return new AiCopilot.GenAiCitationInput(null, result);
+        }
+
         for (Object row : rows) {
             List<Object> values = (List<Object>) row;
             String url = (String) values[0];

--- a/force-app/main/default/classes/PresignedCitations.cls
+++ b/force-app/main/default/classes/PresignedCitations.cls
@@ -1,10 +1,4 @@
-@SuppressWarnings('PMD.ApexSuggestUsingNamedCred')
-public virtual with sharing class PresignedCitations {
-
-    private static final String QUERY_SQL_ENDPOINT = '/services/data/v66.0/ssot/query-sql';
-
-    @TestVisible
-    private static String mockedRestResponse;
+public with sharing class PresignedCitations {
 
     private String chunkDmo;
     private String directoryDmo;
@@ -26,7 +20,7 @@ public virtual with sharing class PresignedCitations {
             quoted.add('\'' + String.escapeSingleQuotes(docId) + '\'');
         }
 
-        String responseBody = queryCdpRest(
+        String responseBody = DataCloudSql.query(
             'SELECT get_presigned_url(TABLE(' + directoryDmo + '), d.ResolvedFilePath__c, 180), d.ResolvedFilePath__c ' +
             'FROM "' + directoryDmo + '" d ' +
             'WHERE d.FilePath__c IN (' + String.join(quoted, ', ') + ')'
@@ -64,26 +58,5 @@ public virtual with sharing class PresignedCitations {
         }
 
         return new AiCopilot.GenAiCitationInput(null, result);
-    }
-
-
-    // PROTECTED
-
-    @TestVisible
-    protected virtual String queryCdpRest(String sql) {
-        if (Test.isRunningTest() && mockedRestResponse != null) {
-            return mockedRestResponse;
-        }
-
-        HttpRequest request = new HttpRequest();
-        request.setMethod('POST');
-        request.setHeader('Authorization', 'Bearer ' + new SessionId().asString());
-        request.setHeader('Content-Type', 'application/json');
-        request.setEndpoint(Url.getOrgDomainURL().toExternalForm() + QUERY_SQL_ENDPOINT);
-        request.setBody(JSON.serialize(new Map<String, String>{ 'sql' => sql }));
-
-        HttpResponse response = new Http().send(request);
-
-        return response.getBody();
     }
 }

--- a/force-app/main/default/classes/PresignedCitations_Test.cls
+++ b/force-app/main/default/classes/PresignedCitations_Test.cls
@@ -6,7 +6,7 @@ private class PresignedCitations_Test {
     private static void buildsCitationWithUrlAndFileName() {
 
         // Setup
-        PresignedCitations.mockedRestResponse = '{"data":[["https://presigned.example.com/policy.pdf?token=abc","1JDRK000005/policy.pdf"]],"metadata":[]}';
+        DataCloudSql.mockedResponse = '{"data":[["https://presigned.example.com/policy.pdf?token=abc","1JDRK000005/policy.pdf"]],"metadata":[]}';
 
         // Exercise
         AiCopilot.GenAiCitationInput result = new PresignedCitations('ADL_MyOrgButlerLibr_chunk__dlm')


### PR DESCRIPTION
## Summary
- **Extract `DataCloudSql` class** — shared REST callout to `/ssot/query-sql` with session auth and HTTP error handling, replacing duplicated callout code in `DataLibrary` and `PresignedCitations`
- **Remove `ConnectApi.CdpQuery` compile-time dependency** from `DataLibrary` — replace with internal `QueryResult`/`QueryRow` types populated from the REST response, so the package installs in orgs without Data Cloud
- **Graceful failure** — wrap `DataLibrary.retrieve()` in try-catch so callout errors (e.g. Data Cloud not enabled) return an empty result instead of crashing the agent

Fixes #55
Fixes #57

## Test plan
- [x] All 9 `DataLibrary_Test` tests pass (including new `returnsEmptyOnException`)
- [x] `PresignedCitations_Test` passes
- [x] End-to-end verified via anonymous Apex: `SearchDataLibrary.execute()` returns answer with presigned citation URLs
- [ ] Install package in an org without Data Cloud enabled — should install without errors
- [ ] Trigger SearchDataLibrary in a non-Data Cloud org — should fail gracefully (empty result, no exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)