### PR TITLE
Check document size and pro actively switch to chunk only for large d…

### DIFF
--- a/force-app/main/default/classes/SearchDataLibrary.cls
+++ b/force-app/main/default/classes/SearchDataLibrary.cls
@@ -5,63 +5,41 @@ global with sharing class SearchDataLibrary {
     @TestVisible
     private static DataLibrary libraryOverride;
 
+    @TestVisible
+    private static final Integer MAX_DOCUMENT_LENGTH = 250000;
+
     @InvocableMethod(label='MyOrgButler: Search Data Library' description='Search company documents in a Data Cloud data library and return answers grounded in the source files.')
     global static List<Output> execute(List<Input> inputs) {
         Output result = new Output();
 
-        try {
-            result = answerFromFullDocument(inputs[0]);
-        }
-        catch (PromptTemplate.PromptTemplateException error) {
-            if(!isTokenLimit(error)) {
-                throw error;
-            }
-
-            result = answerFromChunks(inputs[0]);
-        }
+        result = answerFrom(inputs[0]);
 
         return new List<Output>{ result };
     }
 
 
     // PRIVATE
-
-    private static Output answerFromFullDocument(Input input) {
-        return answerFrom(input, false);
-    }
-
-
-    private static Output answerFromChunks(Input input) {
-        return answerFrom(input, true);
-    }
-
     
-    private static Output answerFrom(Input input, Boolean chunksOnly) {
+    private static Output answerFrom(Input input) {
         DataLibrary library = libraryOverride != null ? libraryOverride : new DataLibrary();
-        DataLibrary.Result data = library.retrieve(input.question, input.chunkDmo, chunksOnly);
+        DataLibrary.Result data = library.retrieve(input.question, input.chunkDmo, false);
+
+        // Note: If the full document is too long, we use the chunks only approach.
+        if(data.documents.length() > MAX_DOCUMENT_LENGTH) {
+            data = library.retrieve(input.question, input.chunkDmo, true);
+        }
 
         Output result = new Output();
         result.citations = data.citations;
-        result.answer = answerFrom(input.question, data.documents);
+        result.answer = new PromptTemplate('AnswerFromDocuments')
+                                    .call(new Map<String, Object>{
+                                        'Input:userQuestion' => input.question,
+                                        'Input:documents' => data.documents
+                                    })
+                                    .text;
         return result;
     }
 
-    private static Boolean isTokenLimit(PromptTemplate.PromptTemplateException error) {
-        String message = error.getMessage();
-        return message != null
-            && (message.containsIgnoreCase('exceeds the token limit')
-            ||  message.containsIgnoreCase('exceeds model size limit'));
-    }
-
-
-    private static String answerFrom(String question, String documents) {
-        return new PromptTemplate('AnswerFromDocuments')
-            .call(new Map<String, Object>{
-                'Input:userQuestion' => question,
-                'Input:documents' => documents
-            })
-            .text;
-    }
 
 
     // INNER

--- a/force-app/main/default/classes/SearchDataLibrary_Test.cls
+++ b/force-app/main/default/classes/SearchDataLibrary_Test.cls
@@ -19,12 +19,12 @@ private class SearchDataLibrary_Test {
 
 
     @IsTest
-    private static void fallsBackToChunks() {
+    private static void fallsBackToChunksWhenFullDocumentIsTooLong() {
 
         // Setup
         DataLibrarySpy spy = new DataLibrarySpy();
+        spy.oversizedOnFullRetrieval = true;
         SearchDataLibrary.libraryOverride = spy;
-        PromptTemplate.mockedErrorMessage = 'Prompt size exceeds the token limit';
 
 
         // Exercise
@@ -39,11 +39,11 @@ private class SearchDataLibrary_Test {
 
 
     @IsTest
-    private static void rethrowsUnrelatedErrors() {
+    private static void rethrowsPromptTemplateErrors() {
 
         // Setup
         SearchDataLibrary.libraryOverride = new DataLibrarySpy();
-        PromptTemplate.mockedErrorMessage = 'Einstein had an unrelated glitch';
+        PromptTemplate.mockedErrorMessage = 'Einstein had a glitch';
 
 
         // Exercise
@@ -78,13 +78,18 @@ private class SearchDataLibrary_Test {
 
     private class DataLibrarySpy extends DataLibrary {
         public Boolean chunksOnlySeen = false;
+        public Boolean oversizedOnFullRetrieval = false;
 
         public override DataLibrary.Result retrieve(String query, String chunkDmo, Boolean chunksOnly) {
             if (chunksOnly) {
                 chunksOnlySeen = true;
             }
 
-            return new DataLibrary.Result();
+            DataLibrary.Result result = new DataLibrary.Result();
+            if (!chunksOnly && oversizedOnFullRetrieval) {
+                result.documents = 'x'.repeat(SearchDataLibrary.MAX_DOCUMENT_LENGTH +1);
+            }
+            return result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #61. That change caught `PromptTemplateException` and matched
  on the message substring ("exceeds the token limit" / "exceeds model size limit")
  to decide when to retry with chunks-only. In practice the Einstein prompt
  template still threw unhandled exceptions — the error text we were matching
  wasn't the text we actually got, and relying on a vendor-controlled message
  string is fragile by design (it can change without notice).
- Now `SearchDataLibrary` proactively checks `data.documents.length()` after the
  full-document retrieval. If it exceeds `MAX_DOCUMENT_LENGTH` (250,000 chars),
  it re-retrieves in chunks-only mode before calling the prompt template.
- The try/catch and message-matching helper are gone. Any `PromptTemplateException`
  now propagates, which is what the caller already expected for non-size errors.

## Test plan
- [ ] `sf apex run test --class-names SearchDataLibrary_Test` — 3 tests pass
  (`execute`, `fallsBackToChunksWhenFullDocumentIsTooLong`, `rethrowsPromptTemplateErrors`)
- [ ] Testing Center `Regression` suite — SearchDataLibrary case still green
- [ ] Manually ask a question that hits a large document in the data library and
      confirm the agent answers without a prompt-template error
