### PR TITLE
Add Node runner for multi-turn agent REST tests

### DIFF
--- a/.claude/skills/agentforce/commands/eval.md
+++ b/.claude/skills/agentforce/commands/eval.md
@@ -110,15 +110,17 @@ Multi-turn agent specs live in `agent-eval/`:
 - `demo-story.yaml` — the conference demo workflow.
 - `prompt-regression.yaml` — smoke tests that exercise specific prompt templates (`ConsolidateMemory`, `AnswerFromFile`) through the agent.
 
-Each entry has plain-English `expect` criteria. Claude drives the agent over the in-org Invocable Action REST endpoint, keeps the transcript in memory, and judges each turn against `expect`.
+Split of responsibilities:
+- **Mechanical work** — REST calls, session chaining, `agentResponse.value` unwrap, parallelism, transcript capture — handled by `.claude/skills/agentforce/run.mjs`.
+- **Judgment** — grading each turn's reply against its plain-English `expect` — handled by Claude in this conversation.
 
-Why this endpoint: the `generateAiAgentResponse` invocable action is exposed at `/services/data/vXX.X/actions/custom/generateAiAgentResponse/<AgentApiName>`. `sf api request rest` hits it with the CLI's existing org auth — no Connected App, no JWT, no api.salesforce.com. Returns `sessionId` + `agentResponse` directly as JSON. Multi-turn works by passing the `sessionId` back into the next call.
+Why this endpoint: the `generateAiAgentResponse` invocable action is exposed at `/services/data/vXX.X/actions/custom/generateAiAgentResponse/<AgentApiName>`. `sf api request rest` hits it with the CLI's existing org auth — no Connected App, no JWT, no api.salesforce.com. Multi-turn works by passing the returned `sessionId` back into the next call.
 
-What it can't observe: planner trace (which topic routed, which actions invoked). That data lives in Data Cloud DLM tables; the `ConversationDefinitionEventLog` only captures dialog-level events with sensitive fields redacted. Topic/action assertions stay in Testing Center.
+What this layer can't observe: planner trace (which topic routed, which actions invoked). That data lives in Data Cloud DLM tables; the `ConversationDefinitionEventLog` only captures dialog-level events with sensitive fields redacted. Topic/action assertions stay in Testing Center.
 
 ### Spec format
 
-Each test has a `name`, a top-level `description` summarizing the scenario, and a `turns:` list. All turns in a test share one agent session — context carries via the returned `sessionId`. Use this layer for scenarios that single-turn Testing Center cases can't capture; per-action regression stays in `Regression.aiEvaluationDefinition-meta.xml`.
+Each test has a `name`, a top-level `description`, and a `turns:` list. All turns in a test share one agent session — context carries via the returned `sessionId`. Use this layer for scenarios that single-turn Testing Center cases can't capture; per-action regression stays in `Regression.aiEvaluationDefinition-meta.xml`.
 
 ```yaml
 agent: MyOrgButler
@@ -135,56 +137,62 @@ tests:
         expect: Confirms a task was created on the Acme opportunity, mentions VP approval or discount
 ```
 
-`expect` is plain English — Claude grades the agent's reply against it. No substring matching. Per-turn `turn` is a short label that surfaces in the run output and helps disambiguate failures.
+A test can also be single-turn (`say`/`expect` at the test level instead of `turns:`). `expect` is plain English — graded by Claude, not substring-matched. The runner's mini YAML parser only handles this subset (quoted or plain scalars, the `tests`/`turns` shape); don't introduce anchors, multi-line scalars, or merge keys.
 
-### Running one test
-
-```bash
-ORG=my-org-butler_DEV
-AGENT=MyOrgButler
-SESSION=""
-
-# Turn 1
-body=$(jq -n --arg msg "$utterance" '{inputs:[{userMessage:$msg}]}')
-resp=$(sf api request rest -o "$ORG" \
-  "/services/data/v66.0/actions/custom/generateAiAgentResponse/$AGENT" \
-  -X POST -H "Content-Type:application/json" -b "-" <<<"$body")
-
-SESSION=$(jq -r '.[0].outputValues.sessionId' <<<"$resp")
-text=$(jq -r '.[0].outputValues.agentResponse | fromjson | .value // .' <<<"$resp")
-ok=$(jq -r '.[0].isSuccess' <<<"$resp")
-err=$(jq -r '.[0].errors // empty' <<<"$resp")
-
-# Turn 2 (and subsequent) — pass sessionId back
-body=$(jq -n --arg msg "$next" --arg sid "$SESSION" \
-  '{inputs:[{userMessage:$msg, sessionId:$sid}]}')
-resp=$(sf api request rest -o "$ORG" \
-  "/services/data/v66.0/actions/custom/generateAiAgentResponse/$AGENT" \
-  -X POST -H "Content-Type:application/json" -b "-" <<<"$body")
-```
-
-`agentResponse` is wrapped as `{"type":"Text","value":"..."}` — unwrap to `.value` for judging. If unwrap fails, fall back to the raw string (some action errors come through unwrapped).
-
-### Running the full suite
-
-Each test (across both `demo-story.yaml` and `prompt-regression.yaml`) is independent (its own session). Run them in parallel:
+### Running
 
 ```bash
-mkdir -p /tmp/ae && rm -f /tmp/ae/*.txt
-# Iterate spec.tests[]: for each test, drive its turns over REST,
-# write the in-memory transcript to /tmp/ae/<name>.txt as it goes.
-# Background each test with & and `wait` for all to finish.
+node .claude/skills/agentforce/run.mjs agent-eval/demo-story.yaml --org my-org-butler_DEV
+node .claude/skills/agentforce/run.mjs agent-eval/prompt-regression.yaml --org my-org-butler_DEV
 ```
 
-Then walk each transcript and grade against the corresponding `expect` strings. Print:
+Both can run in parallel (each test has its own session, no cross-spec coupling):
+
+```bash
+mkdir -p /tmp/ae && rm -f /tmp/ae/*.json
+node .claude/skills/agentforce/run.mjs agent-eval/demo-story.yaml --org my-org-butler_DEV &
+node .claude/skills/agentforce/run.mjs agent-eval/prompt-regression.yaml --org my-org-butler_DEV &
+wait
+```
+
+Flags: `--out <dir>` (default `/tmp/ae`), `--concurrency <N>` (default 4 — parallelism *within* a single spec), `--api-version <vXX.X>` (default `v66.0`).
+
+### Output
+
+One JSON transcript per test at `/tmp/ae/<test-name>.json`:
+
+```json
+{
+  "name": "SalesRepMondayMorning",
+  "description": "...",
+  "agent": "MyOrgButler",
+  "sessionId": "af54...",
+  "turns": [
+    {
+      "turn": "Prioritize: what needs my attention?",
+      "say": "which opportunity should I work on next?",
+      "expect": "Recommends the Acme Q1 Expansion Deal as top priority",
+      "isSuccess": true,
+      "errors": null,
+      "reply": "...the agent's unwrapped reply...",
+      "rawAgentResponse": "{\"type\":\"Text\",\"value\":\"...\"}",
+      "elapsedMs": 8234
+    }
+  ]
+}
+```
+
+Runner exit code: non-zero if any test had a REST-level failure (`isSuccess=false` or `sf` crashed). Note that a REST-level pass doesn't mean the reply meets the `expect` — that's the judging step.
+
+### Judging
+
+Read each `/tmp/ae/<name>.json`, walk `turns`, and grade `reply` against `expect` per turn. Surface `errors` verbatim. Print the table:
 
 ```
-CallRestApi              PASS  Task record returned with subject Call Burlington.
-QueryRecordsWithSoql     FAIL  Listed 5 opportunities but didn't single out Acme.
-SalesRepMondayMorning    PASS  All 7 turns met expectations.
+SalesRepMondayMorning           PASS  All 7 turns met expectations.
+ConsolidateMemoryConflict       FAIL  Turn 3 returned the older Amount-sort preference, not CloseDate.
+AnswerFromFileContractValue     PASS  Mentions $500K total and the three phase amounts.
 ```
-
-Surface `errors` from the response verbatim — the JSON is descriptive.
 
 ### Prerequisites
 

--- a/.claude/skills/agentforce/run.mjs
+++ b/.claude/skills/agentforce/run.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+// Drives a multi-turn YAML spec against a deployed Agentforce agent over the
+// in-org Invocable Action REST endpoint. Captures per-test transcripts as JSON
+// for the caller (Claude) to judge against each turn's `expect`. Mechanical only —
+// no judging, no LLM calls.
+//
+// Usage:
+//   node run.mjs <spec.yaml> --org <ORG> [--out <dir>] [--concurrency <N>] [--api-version <vXX.X>]
+//
+// Output (per test): <out>/<test-name>.json with the full turn-by-turn transcript.
+// Exits non-zero if any test had a REST-level failure (isSuccess=false or sf crashed).
+
+import { spawn } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+// ---------- Mini YAML parser ----------
+// Handles only the subset used in agent-eval/*.yaml: top-level scalars and
+// a `tests:` list, where each item is a mapping with optional nested `turns:` list.
+// Keys are simple identifiers; values are quoted ('...' or "...", no escapes) or
+// rest-of-line plain scalars. Comments start with `#` (preceded by whitespace or BOL).
+function parseYAML(text) {
+  const stripComment = (raw) => {
+    let inS = false, inD = false;
+    for (let j = 0; j < raw.length; j++) {
+      const c = raw[j];
+      if (c === "'" && !inD) inS = !inS;
+      else if (c === '"' && !inS) inD = !inD;
+      else if (c === '#' && !inS && !inD && (j === 0 || /\s/.test(raw[j - 1]))) {
+        return raw.slice(0, j);
+      }
+    }
+    return raw;
+  };
+
+  const lines = text.split('\n').map((raw, i) => {
+    const stripped = stripComment(raw).replace(/\s+$/, '');
+    if (!stripped.trim()) return null;
+    const indent = stripped.match(/^ */)[0].length;
+    return { lineNo: i + 1, indent, body: stripped.slice(indent) };
+  }).filter(Boolean);
+
+  let pos = 0;
+
+  const parseScalar = (raw) => {
+    const s = raw.trim();
+    if (s === '') return '';
+    if (s.length >= 2 && s[0] === "'" && s[s.length - 1] === "'") return s.slice(1, -1);
+    if (s.length >= 2 && s[0] === '"' && s[s.length - 1] === '"') return s.slice(1, -1);
+    return s;
+  };
+
+  const parseValue = (indent) => {
+    if (pos >= lines.length || lines[pos].indent < indent) return null;
+    if (lines[pos].body.startsWith('- ')) return parseList(indent);
+    return parseMap(indent);
+  };
+
+  const parseList = (indent) => {
+    const items = [];
+    while (pos < lines.length && lines[pos].indent === indent && lines[pos].body.startsWith('- ')) {
+      const cur = lines[pos];
+      // Rewrite "- key: value" as a virtual map line at indent+2 so parseMap picks it up.
+      lines[pos] = { ...cur, indent: indent + 2, body: cur.body.slice(2) };
+      items.push(parseMap(indent + 2));
+    }
+    return items;
+  };
+
+  const parseMap = (indent) => {
+    const obj = {};
+    while (pos < lines.length && lines[pos].indent === indent && !lines[pos].body.startsWith('- ')) {
+      const line = lines[pos];
+      const m = line.body.match(/^([A-Za-z_][\w-]*):(?:\s+(.*))?\s*$/);
+      if (!m) throw new Error(`YAML parse error at line ${line.lineNo}: ${line.body}`);
+      const key = m[1];
+      const inlineVal = m[2];
+      pos++;
+      if (inlineVal !== undefined && inlineVal !== '') {
+        obj[key] = parseScalar(inlineVal);
+      } else if (pos < lines.length && lines[pos].indent > indent) {
+        obj[key] = parseValue(lines[pos].indent);
+      } else {
+        obj[key] = null;
+      }
+    }
+    return obj;
+  };
+
+  return parseValue(0) ?? {};
+}
+
+// ---------- sf invocation ----------
+function callAgent({ org, agent, apiVersion, userMessage, sessionId }) {
+  return new Promise((res, rej) => {
+    const inputs = sessionId ? { userMessage, sessionId } : { userMessage };
+    const body = JSON.stringify({ inputs: [inputs] });
+    const url = `/services/data/${apiVersion}/actions/custom/generateAiAgentResponse/${agent}`;
+    const p = spawn('sf', [
+      'api', 'request', 'rest', '-o', org, url,
+      '-X', 'POST', '-H', 'Content-Type:application/json', '-b', '-',
+    ]);
+    let stdout = '', stderr = '';
+    p.stdout.on('data', (d) => { stdout += d; });
+    p.stderr.on('data', (d) => { stderr += d; });
+    p.on('error', rej);
+    p.on('close', (code) => {
+      if (code !== 0) {
+        rej(new Error(`sf exited ${code}: ${(stderr.trim() || stdout.trim()).slice(0, 800)}`));
+        return;
+      }
+      try { res(JSON.parse(stdout)); }
+      catch (e) { rej(new Error(`Non-JSON sf output: ${e.message}\n${stdout.slice(0, 500)}`)); }
+    });
+    p.stdin.end(body);
+  });
+}
+
+const unwrapAgentResponse = (raw) => {
+  if (typeof raw !== 'string') return raw == null ? null : String(raw);
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && 'value' in parsed) return parsed.value;
+  } catch { /* fall through */ }
+  return raw;
+};
+
+// ---------- Per-test driver ----------
+async function runTest({ test, org, agent, apiVersion, outDir }) {
+  const turns = Array.isArray(test.turns) && test.turns.length
+    ? test.turns
+    : [{ turn: test.turn ?? null, say: test.say, expect: test.expect }];
+
+  const transcript = {
+    name: test.name,
+    description: test.description ?? null,
+    agent, org, apiVersion,
+    sessionId: null,
+    turns: [],
+  };
+
+  let sessionId = null;
+  let allOk = true;
+
+  for (const t of turns) {
+    const start = Date.now();
+    let resp = null, callError = null;
+    try {
+      resp = await callAgent({ org, agent, apiVersion, userMessage: t.say, sessionId });
+    } catch (e) {
+      callError = e.message;
+    }
+    const elapsedMs = Date.now() - start;
+
+    if (callError) {
+      transcript.turns.push({
+        turn: t.turn ?? null, say: t.say, expect: t.expect ?? null,
+        isSuccess: false, errors: callError, reply: null, rawAgentResponse: null, elapsedMs,
+      });
+      allOk = false;
+      break;
+    }
+
+    const item = Array.isArray(resp) ? resp[0] : resp;
+    const isSuccess = item?.isSuccess === true;
+    const errors = item?.errors ?? null;
+    const out = item?.outputValues ?? {};
+    if (out.sessionId) sessionId = out.sessionId;
+    transcript.sessionId = sessionId;
+    const raw = out.agentResponse ?? null;
+
+    transcript.turns.push({
+      turn: t.turn ?? null, say: t.say, expect: t.expect ?? null,
+      isSuccess, errors,
+      reply: unwrapAgentResponse(raw),
+      rawAgentResponse: raw,
+      elapsedMs,
+    });
+
+    if (!isSuccess) { allOk = false; break; }
+  }
+
+  const path = resolve(outDir, `${test.name}.json`);
+  await writeFile(path, JSON.stringify(transcript, null, 2) + '\n');
+  return { name: test.name, path, ok: allOk, turnCount: transcript.turns.length };
+}
+
+// ---------- Async pool ----------
+async function runPool(items, concurrency, fn) {
+  const queue = items.slice();
+  const out = [];
+  const worker = async () => {
+    while (queue.length) {
+      const item = queue.shift();
+      out.push(await fn(item));
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) || 1 }, worker));
+  return out;
+}
+
+// ---------- Main ----------
+const { values, positionals } = parseArgs({
+  options: {
+    org: { type: 'string' },
+    out: { type: 'string', default: '/tmp/ae' },
+    concurrency: { type: 'string', default: '4' },
+    'api-version': { type: 'string', default: 'v66.0' },
+  },
+  allowPositionals: true,
+});
+
+if (positionals.length === 0 || !values.org) {
+  console.error('Usage: node run.mjs <spec.yaml> --org <ORG> [--out <dir>] [--concurrency <N>] [--api-version <vXX.X>]');
+  process.exit(2);
+}
+
+const specPath = positionals[0];
+const spec = parseYAML(await readFile(specPath, 'utf8'));
+if (!spec.agent || !Array.isArray(spec.tests)) {
+  console.error(`Spec must declare top-level 'agent' and 'tests'. Got keys: ${Object.keys(spec).join(', ')}`);
+  process.exit(2);
+}
+
+await mkdir(values.out, { recursive: true });
+
+const concurrency = Math.max(1, parseInt(values.concurrency, 10));
+console.error(`Running ${spec.tests.length} test(s) from ${specPath} against ${spec.agent} on ${values.org} (concurrency=${concurrency})`);
+console.error(`Transcripts → ${values.out}/`);
+
+let started = 0;
+const results = await runPool(spec.tests, concurrency, async (test) => {
+  const idx = ++started;
+  const t0 = Date.now();
+  console.error(`[${idx}/${spec.tests.length}] ${test.name} START`);
+  try {
+    const r = await runTest({
+      test, org: values.org, agent: spec.agent,
+      apiVersion: values['api-version'], outDir: values.out,
+    });
+    const took = ((Date.now() - t0) / 1000).toFixed(1);
+    console.error(`[${idx}/${spec.tests.length}] ${test.name} ${r.ok ? 'OK' : 'REST_ERROR'} ${r.turnCount} turn(s) (${took}s) → ${r.path}`);
+    return r;
+  } catch (e) {
+    console.error(`[${idx}/${spec.tests.length}] ${test.name} CRASH: ${e.message}`);
+    return { name: test.name, ok: false, error: e.message };
+  }
+});
+
+const failed = results.filter((r) => !r.ok);
+console.error(`\nDone. ${results.length - failed.length}/${results.length} REST-OK.`);
+if (failed.length) console.error(`Failed: ${failed.map((r) => r.name).join(', ')}`);
+process.exit(failed.length ? 1 : 0);


### PR DESCRIPTION
## Summary

- Adds [`.claude/skills/agentforce/run.mjs`](.claude/skills/agentforce/run.mjs): a small Node runner that reads a multi-turn YAML spec (`agent-eval/demo-story.yaml`, `agent-eval/prompt-regression.yaml`), drives the conversation over the in-org `generateAiAgentResponse` REST endpoint via `sf api request rest`, chains `sessionId`, unwraps `agentResponse.value`, runs tests in parallel, and writes one transcript JSON per test to `/tmp/ae/<name>.json`.
- Rewrites the REST section of [`.claude/skills/agentforce/commands/eval.md`](.claude/skills/agentforce/commands/eval.md) to invoke the runner instead of regenerating bash+jq+python from scratch each run. Claude is now responsible only for judging transcripts against each turn's plain-English `expect`.

Motivation: the previous skill prose required Claude to assemble the REST plumbing (escaping, session chaining, response unwrap, parallelism) on each invocation, which kept hitting small mechanical bugs. Splitting it like promptfoo does — deterministic runner + LLM judge — freezes the mechanical work and keeps only the LLM-shaped step in the conversation.

No npm dependencies — runner vendors a minimal YAML parser covering only the subset our specs use.

## Test plan

- [x] Parser smoke test: parses `demo-story.yaml` (1 test, 7 turns) and `prompt-regression.yaml` (3 tests, 7 turns) into the expected shape.
- [x] Live run against `my-org-butler_DEV`: both specs in parallel, all 14 turns REST-OK, transcripts written to `/tmp/ae/`.
- [x] CLI prints clear usage on missing args and exits non-zero.
- [ ] Reviewer: try `node .claude/skills/agentforce/run.mjs agent-eval/demo-story.yaml --org my-org-butler_DEV` end-to-end and confirm the transcript JSONs land in `/tmp/ae/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)