### PR TITLE
feat: AI Issue-to-PR Pipeline

### DIFF
--- a/.claude/skills/ai-maintenance/SKILL.md
+++ b/.claude/skills/ai-maintenance/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ai-maintenance
+description: AI Issue-to-PR pipeline — triage GitHub issues and implement Apex/LWC fixes for My Org Butler
+argument-hint: "triage|implement"
+---
+
+# AI Maintenance
+
+## Commands
+
+- **`triage`** — Read `commands/triage.md`. Classify a GitHub issue as AUTOMATABLE, NEEDS_INFO, or NEEDS_HUMAN.
+- **`implement`** — Read `commands/implement.md`. Write an Apex/LWC fix, run tests, open a PR.
+
+If no argument is given, ask what the user wants to do.

--- a/.claude/skills/ai-maintenance/commands/implement.md
+++ b/.claude/skills/ai-maintenance/commands/implement.md
@@ -1,0 +1,43 @@
+# Implement
+
+You are an AI developer fixing a GitHub issue in the My Org Butler Salesforce DX project.
+
+## What You May Touch
+
+- `force-app/main/default/classes/` — Apex classes and test classes
+- `force-app/main/default/lwc/` — Lightning Web Components
+
+## What You Must NOT Touch
+
+- `genAiFunctions`, `genAiPromptTemplates`, `genAiPlugins`, `genAiPlannerBundles` — Agentforce metadata
+- `unpackaged/` — agent and bot definitions
+- `agent-eval/` — test specs
+- `config/` — scratch org definition
+- `sfdx-project.json`, `package.json`
+- `.github/workflows/`
+- `CLAUDE.md`, `scripts/`
+- Permission Sets, Custom Metadata, Flows
+
+If the fix requires any of the above, stop and post a comment on the issue with `gh issue comment <number> --body "..."` explaining what human input is needed. Label it `needs-human` with `gh issue edit <number> --add-label needs-human`. Do not open a PR.
+
+## Apex Rules
+
+- All SOQL must use bind variables — no string concatenation in queries
+- All DML outside loops — bulkify everything
+- Test classes: minimum 85% coverage, use `@TestSetup`, no `seeAllData=true`
+- Use the API version from `sfdx-project.json`
+- Follow the patterns already used in the surrounding code — check adjacent classes first
+
+## Steps
+
+1. Create a branch: `git checkout -b ai/issue-<number>`
+2. Read the issue. Identify which class or component is responsible.
+3. Read the affected file(s) in full before making changes.
+4. Write the fix. Write or update the corresponding test class.
+5. Commit: `git add <changed files> && git commit -m "fix: <short description> (closes #<number>)"`
+6. Push: `git push origin ai/issue-<number>`
+7. Open a PR with `gh pr create`:
+   - Title: `fix: <short description>`
+   - Body: link to the issue (`Closes #<number>`), one-paragraph summary of what changed and why
+
+Do not run `sf project deploy start` — CI handles validation.

--- a/.claude/skills/ai-maintenance/commands/triage.md
+++ b/.claude/skills/ai-maintenance/commands/triage.md
@@ -1,0 +1,32 @@
+# Triage
+
+You are classifying a GitHub issue in the My Org Butler Salesforce DX project to decide whether an AI agent can fix it autonomously.
+
+## Decision Rules
+
+**AUTOMATABLE** — all of these are true:
+- The bug is in Apex (`force-app/main/default/classes/`) or LWC (`force-app/main/default/lwc/`)
+- No schema changes needed (no new fields, objects, or relationships)
+- No Agentforce metadata changes (no GenAI functions, prompt templates, topics, actions, planner bundles, or bot config)
+- No Flow or Process Builder changes
+- No Permission Set or Custom Metadata changes
+- Reproduction steps are clear enough to understand what is broken
+
+**NEEDS_INFO** — any of these are true:
+- Reproduction steps are missing or ambiguous
+- It's unclear which component is affected
+- The expected vs. actual behavior is not described
+
+**NEEDS_HUMAN** — any of these are true:
+- Requires schema changes (custom fields, objects, relationships)
+- Requires changes to Agentforce metadata (`genAiFunctions`, `genAiPromptTemplates`, `genAiPlugins`, `genAiPlannerBundles`, bot definitions in `unpackaged/`)
+- Requires Data Cloud configuration or data model changes
+- Requires changes to `config/project-scratch-def.json` or `sfdx-project.json`
+- Requires architectural decisions (new design patterns, cross-cutting changes across many classes)
+- Involves External Services or Named Credentials
+
+## Output
+
+Write exactly one word — `AUTOMATABLE`, `NEEDS_INFO`, or `NEEDS_HUMAN` — to `/tmp/triage-decision.txt`.
+
+If NEEDS_INFO or NEEDS_HUMAN, also post a comment on the issue explaining why and what is missing. Use `gh issue comment <number> --body "..."`.

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -1,0 +1,78 @@
+name: AI Fix
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number
+        required: true
+      issue_title:
+        description: Issue title
+        required: true
+      issue_body:
+        description: Issue body
+        required: false
+
+jobs:
+  triage:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ai-fix'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    outputs:
+      decision: ${{ steps.read-decision.outputs.decision }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: |
+            Read .claude/skills/ai-maintenance/commands/triage.md for instructions.
+            Write your final decision as exactly one word (AUTOMATABLE, NEEDS_INFO, or NEEDS_HUMAN)
+            to the file /tmp/triage-decision.txt — nothing else in that file.
+
+            Issue #${{ github.event.issue.number || inputs.issue_number }}: ${{ github.event.issue.title || inputs.issue_title }}
+
+            ${{ github.event.issue.body || inputs.issue_body }}
+          claude_args: "--max-turns 3 --model claude-sonnet-4-6"
+          timeout_minutes: 5
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: read-decision
+        run: |
+          DECISION=$(cat /tmp/triage-decision.txt | tr -d '[:space:]')
+          echo "decision=$DECISION" >> $GITHUB_OUTPUT
+          echo "Triage decision: $DECISION"
+
+  implement:
+    needs: triage
+    if: needs.triage.outputs.decision == 'AUTOMATABLE'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          prompt: |
+            Read .claude/skills/ai-maintenance/commands/implement.md for instructions.
+
+            Fix issue #${{ github.event.issue.number || inputs.issue_number }}: ${{ github.event.issue.title || inputs.issue_title }}
+
+            ${{ github.event.issue.body || inputs.issue_body }}
+          claude_args: "--max-turns 10 --model claude-sonnet-4-6"
+          timeout_minutes: 20
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/salesforce-ci.yml
+++ b/.github/workflows/salesforce-ci.yml
@@ -1,0 +1,68 @@
+name: Salesforce CI
+
+on:
+  pull_request:
+    paths:
+      - 'force-app/**'
+      - 'unpackaged/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Salesforce CLI
+        run: npm install -g @salesforce/cli
+
+      - name: Authenticate Dev Hub
+        run: |
+          echo "${{ secrets.SFDX_AUTH_URL }}" | sf org login sfdx-url --sfdx-url-stdin -a devhub --set-default-dev-hub
+
+      - name: Create scratch org
+        run: |
+          sf org create scratch \
+            --definition-file config/project-scratch-def.json \
+            --alias ci-org \
+            --no-namespace \
+            --duration-days 1 \
+            --set-default \
+            --wait 20
+
+      - name: Set org language and assign permissions
+        run: |
+          sf data update record --sobject User --where "Name='User User'" --values "Languagelocalekey=en_US" --target-org ci-org
+          sf org assign permset --name EinsteinGPTPromptTemplateManager --name AgentPlatformBuilder --target-org ci-org
+
+      - name: Deploy no-namespace shims
+        run: sf project deploy start --source-dir no-namespace --target-org ci-org --concise
+
+      - name: Strip namespace from source
+        # Workspace is ephemeral — no need to restore afterwards
+        run: |
+          sed -i 's/aquiva_os__//g; s/aquiva_os\.//g; s/"namespace": "aquiva_os"/"namespace": ""/g' sfdx-project.json
+          find force-app unpackaged -type f \( -name "*.cls" -o -name "*.xml" -o -name "*.genAiPlannerBundle" -o -name "*.genAiPlugin-meta.xml" -o -name "*.yaml" \) \
+            -exec sed -i 's/aquiva_os__//g; s/aquiva_os\.//g' {} +
+
+      - name: Deploy force-app
+        run: sf project deploy start --source-dir force-app --target-org ci-org --concise --ignore-conflicts
+
+      - name: Deploy unpackaged
+        run: sf project deploy start --source-dir unpackaged --target-org ci-org --concise --ignore-conflicts
+
+      - name: Run Apex tests
+        run: |
+          sf apex run test \
+            --target-org ci-org \
+            --test-level RunLocalTests \
+            --code-coverage \
+            --result-format human \
+            --wait 30
+
+      - name: Delete scratch org
+        if: always()
+        run: sf org delete scratch --target-org ci-org --no-prompt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,10 @@
-# Deploying
+# My Org Butler — Project Rules
+
+## AI Agent (CI)
+
+When running as the `ai-fix` GitHub Actions workflow, follow `.claude/skills/ai-maintenance/commands/implement.md` for the full implementation checklist. The rules below still apply.
+
+## Deploying
 
 Never run `sf project deploy start --source-dir force-app`. The scratch org is namespaceless but some metadata files contain namespace references, so a full deploy always fails. Always deploy only the specific files you changed:
 
@@ -8,7 +14,7 @@ sf project deploy start \
   --source-dir force-app/main/default/classes/Bar.cls
 ```
 
-# Testing Strategy
+## Testing Strategy
 
 Everything lives in `agent-eval/`. Two test layers:
 
@@ -47,7 +53,7 @@ Runner details + spec format in `.claude/skills/agentforce/commands/eval.md` →
 
 Rubrics assert on **specific data** (filenames, dollar amounts, counts) — not vague "confirms it worked." Testing Center uses Salesforce's built-in evaluator (judge model is opaque). Multi-turn REST tests use Claude (this conversation).
 
-# Current State (2026-04-30)
+## Current State (2026-04-30)
 
 Testing Center suite: single `Regression` definition with 14 cases; 2 parallel passes complete in a few minutes without tripping the 10-job concurrency cap.
 


### PR DESCRIPTION
Implements the AI Issue-to-PR pipeline described in #67.

## What's included

- `.github/workflows/ai-fix.yml` — triage (3 turns) + implement (10 turns), triggered by `ai-fix` label or manually via `workflow_dispatch`
- `.github/workflows/salesforce-ci.yml` — scratch org creation, namespace stripping, deploy, Apex tests on every PR touching `force-app/` or `unpackaged/`
- `.claude/skills/ai-maintenance/` — triage and implement runbooks as modular skills
- `CLAUDE.md` — added AI Agent section pointing to the skills

## Secrets required before the workflow can run
- `ANTHROPIC_API_KEY` — from console.anthropic.com
- `CLAUDE_CODE_OAUTH_TOKEN` — from `claude setup-token` (alternative to API key, expires daily)

Part of #67