### PR TITLE
fix: add SuppressWarnings note and remove debug call

### DIFF
--- a/force-app/main/default/classes/DataCloudSql.cls
+++ b/force-app/main/default/classes/DataCloudSql.cls
@@ -1,4 +1,4 @@
-// Note: ApexSuggestUsingNamedCred is a false positive — this class calls the org's own Data Cloud endpoint using the running user's session token, not an external named credential.
+// PMD False Positives: calls own Data Cloud endpoint using session token, no external named credential needed
 @SuppressWarnings('PMD.ApexSuggestUsingNamedCred')
 public with sharing class DataCloudSql {
 

--- a/force-app/main/default/classes/DataCloudSql.cls
+++ b/force-app/main/default/classes/DataCloudSql.cls
@@ -1,3 +1,4 @@
+// Note: ApexSuggestUsingNamedCred is a false positive — this class calls the org's own Data Cloud endpoint using the running user's session token, not an external named credential.
 @SuppressWarnings('PMD.ApexSuggestUsingNamedCred')
 public with sharing class DataCloudSql {
 
@@ -9,7 +10,6 @@ public with sharing class DataCloudSql {
 
     public static String query(String sql) {
 
-        System.debug('sql >>' + sql);
         if (Test.isRunningTest() && mockedResponse != null) {
             return mockedResponse;
         }


### PR DESCRIPTION
Closes #78

---
<!-- ai-run wf=ticket-to-pr model=claude-sonnet-4-6 cost=1.79 tokens=2542920 -->
🤖 `sonnet-4-6` · $1.79 · 2.5M tokens (86 in / 23k out / 2.4M cache read, 121k cache write) · ticket-to-pr _(backfilled from [run 25456866123](https://github.com/aquivalabs/my-org-butler/actions/runs/25456866123))_