### PR TITLE
fix(citations): return GenAiCitationOutput so citations always surface

### DIFF
--- a/force-app/main/default/classes/DataLibrary.cls
+++ b/force-app/main/default/classes/DataLibrary.cls
@@ -183,7 +183,7 @@ public virtual with sharing class DataLibrary {
 
     public class Result {
         public String documents = '';
-        public AiCopilot.GenAiCitationInput citations;
+        public AiCopilot.GenAiCitationOutput citations;
     }
 
 

--- a/force-app/main/default/classes/PresignedCitations.cls
+++ b/force-app/main/default/classes/PresignedCitations.cls
@@ -1,20 +1,18 @@
 public with sharing class PresignedCitations {
 
-    private String chunkDmo;
     private String directoryDmo;
 
 
     // CONSTRUCTOR
 
     public PresignedCitations(String chunkDmo) {
-        this.chunkDmo = chunkDmo;
         this.directoryDmo = chunkDmo.replace('_chunk', '');
     }
 
 
     // PUBLIC
 
-    public AiCopilot.GenAiCitationInput forDocuments(Set<String> documentIds) {
+    public AiCopilot.GenAiCitationOutput forDocuments(Set<String> documentIds) {
         List<String> quoted = new List<String>();
         for (String docId : documentIds) {
             quoted.add('\'' + String.escapeSingleQuotes(docId) + '\'');
@@ -55,24 +53,35 @@ public with sharing class PresignedCitations {
     }
 
 
-    private AiCopilot.GenAiCitationInput toCitations(List<Citation> citations) {
-        List<AiCopilot.GenAiSourceReference> result = new List<AiCopilot.GenAiSourceReference>();
+    // Note: GenAiCitationOutput has package-private fields with no accessible
+    //   setter or list-arg constructor, so JSON.deserialize is the only way to
+    //   populate it from external Apex. Also, the published reference says
+    //   GenAiCitedReference.metadata is a single GenAiCitedReferenceInfo, but the
+    //   runtime requires a List — see issue #60.
+    private AiCopilot.GenAiCitationOutput toCitations(List<Citation> citations) {
+        List<Map<String, Object>> references = new List<Map<String, Object>>();
 
         for (Citation citation : citations) {
-            result.add(new AiCopilot.GenAiSourceReference(
-                null,
-                new List<AiCopilot.GenAiSourceContentInfo>{
-                    new AiCopilot.GenAiSourceContentInfo('DataSource__c', chunkDmo, 'FilePath__c'),
-                    new AiCopilot.GenAiSourceContentInfo('DataSourceObject__c', chunkDmo, directoryDmo),
-                    new AiCopilot.GenAiSourceContentInfo('FilePath__c', directoryDmo, citation.fileName)
-                },
-                new List<AiCopilot.GenAiSourceReferenceInfo>{
-                    new AiCopilot.GenAiSourceReferenceInfo(citation.url, citation.fileName, directoryDmo)
+            references.add(new Map<String, Object>{
+                'metadata' => new List<Map<String, Object>>{
+                    new Map<String, Object>{
+                        'link' => citation.url,
+                        'source_object_record_id' => citation.fileName,
+                        'source_object_api_name' => directoryDmo,
+                        'label' => citation.fileName
+                    }
                 }
-            ));
+            });
         }
 
-        return new AiCopilot.GenAiCitationInput(null, result);
+        String payload = JSON.serialize(new Map<String, Object>{
+            'references' => references
+        });
+
+        AiCopilot.GenAiCitationOutput result = (AiCopilot.GenAiCitationOutput)
+            JSON.deserialize(payload, AiCopilot.GenAiCitationOutput.class);
+
+        return result;
     }
 
 

--- a/force-app/main/default/classes/SearchDataLibrary.cls
+++ b/force-app/main/default/classes/SearchDataLibrary.cls
@@ -58,6 +58,6 @@ global with sharing class SearchDataLibrary {
         global String answer;
 
         @InvocableVariable(label='Citations' description='Source references for the generated answer.')
-        global AiCopilot.GenAiCitationInput citations;
+        global AiCopilot.GenAiCitationOutput citations;
     }
 }

--- a/force-app/main/default/genAiFunctions/SearchDataLibrary/output/schema.json
+++ b/force-app/main/default/genAiFunctions/SearchDataLibrary/output/schema.json
@@ -12,7 +12,7 @@
     "citations" : {
       "title" : "Citations",
       "description" : "Source references for the generated answer.",
-      "lightning:type" : "@apexClassType/AiCopilot__GenAiCitationInput",
+      "lightning:type" : "@apexClassType/AiCopilot__GenAiCitationOutput",
       "lightning:isPII" : false,
       "copilotAction:isDisplayable" : false,
       "copilotAction:isUsedByPlanner" : false,


### PR DESCRIPTION
## Summary

- Switches `SearchDataLibrary` from `AiCopilot.GenAiCitationInput` to `AiCopilot.GenAiCitationOutput` so the citation chip surfaces deterministically instead of being subject to LLM discretion.
- Updates `PresignedCitations` to build the new output shape via `JSON.deserialize` — the only way to populate `GenAiCitationOutput.references` from external Apex.
- Updates `genAiFunctions/SearchDataLibrary/output/schema.json` to declare the citations field as `AiCopilot__GenAiCitationOutput`.

## Why

Per the [Salesforce docs](https://developer.salesforce.com/docs/einstein/genai/guide/citations.html):
- `GenAiCitationInput` adds citations to the reasoning engine's context — the LLM decides whether/how to surface them.
- `GenAiCitationOutput` bypasses the reasoning engine and attaches citations directly to the response.

Reproduced issue #60 by running the failing prompt against the deployed agent 3×: 2 runs cited `policy.pdf` inline, 1 run answered correctly but never named the source file. The Apex action returned valid citations every time — the LLM was just dropping them.

## Notes

- `GenAiCitationOutput.references` is package-private — no accessible setter, list-arg constructor, or add method. Confirmed via live probing in the org. `JSON.deserialize` is the only construction path from external Apex.
- The published reference describes `GenAiCitedReference.metadata` as a single `GenAiCitedReferenceInfo`, but the runtime requires a `List` — also verified by live probe.

## Test plan

- [x] `PresignedCitations_Test`, `DataLibrary_Test`, `SearchDataLibrary_Test` — 13/13 pass
- [x] Live Apex probe: `DataLibrary.retrieve()` returns a fully-populated `GenAiCitationOutput` with `policy.pdf` + presigned URL on every call
- [x] Schema verified via `sf project retrieve` — org's deployed `output/schema.json` now declares `@apexClassType/AiCopilot__GenAiCitationOutput`
- [x] UI verified — citation chip surfaces correctly on the discount-policy question

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)